### PR TITLE
Fixing github-auto-deploy setup

### DIFF
--- a/README.md
+++ b/README.md
@@ -134,15 +134,24 @@ $ ansible-playbook -i provisioning/development provisioning/bootstrap-digitaloce
 $ ansible-playbook -i provisioning/development provisioning/site-dev.yml
 ```
 
-A post-commit webhook is used to automatically pull the latest changes from the repositories master branch and rebuild the Jekyll site using the [Github Auto Deploy](https://github.com/logsol/Github-Auto-Deploy) application.
+A post-commit webhook is used to automatically pull the latest changes from the repositories master branch and rebuild the Jekyll site.
 
 A [new webhook](https://github.com/felnne/bas-style-kit/settings/hooks/new) will need to be configured in GitHub using the following values:
 
-* Payload URL: `http://bas-style-kit.web.nerc-bas.ac.uk`
+* Payload URL: `http://bas-style-kit.web.nerc-bas.ac.uk:8001`
 * Content type: `application/json`
 * Secret: Leave blank
 * Which events would you like to trigger this webhook: `Just the push event`
 * Active: `true`
+
+The server side application which will respond to this webhook uses [Github Auto Deploy](https://github.com/logsol/Github-Auto-Deploy), which should be started as a background process:
+
+```shell
+$ bas-style-kit-dev-web2.web.nerc-bas.ac.uk
+$ cd /app/provisioning/scripts/github-auto-deploy
+
+$ ./GitAutoDeploy.py --daemon-mode
+```
 
 [1]
 

--- a/provisioning/site-dev.yml
+++ b/provisioning/site-dev.yml
@@ -16,8 +16,8 @@
       copy: src="certificates/star.web.nerc-bas.ac.uk/star.web.nerc-bas.ac.uk-certificate-including-trust-chain.crt" dest="/app/provisioning/certificates/star.web.nerc-bas.ac.uk/star.web.nerc-bas.ac.uk-certificate-including-trust-chain.crt"
     - name: set owner for app directory
       file: path="{{ app_root }}" owner=app group=app recurse=yes state=directory
-    - name: start webhook server as a daemon to rebuild documentation on push
-      command: "{{ app_root }}/provisioning/scripts/github-auto-deploy/GitAutoDeploy.py --daemon-mode"
+    - name: set execute permissions on git-auto-deploy application
+      file: path="{{ app_root }}/provisioning/scripts/github-auto-deploy/GitAutoDeploy.py" mode=0775
 
 - name: setup web-servers
   hosts: bas-style-kit-webservers-dev


### PR DESCRIPTION
Once started in daemon mode this script doesn't gracefull respond to being started again (which is fair enough).

Therefore starting the script is now a manual task, however execute permissions still need to be assigned to this file so it can be run, so this is done automatically.
